### PR TITLE
Modify path to be correct for sequences

### DIFF
--- a/pipeline_plugins/resource/hook/collect_assets.py
+++ b/pipeline_plugins/resource/hook/collect_assets.py
@@ -116,6 +116,9 @@ def create_job(event):
 
                         shutil.copy(path, dst)
                 else:
+                    if component_data['system_type'] == 'sequence':
+                        src = src % 1
+
                     basename = format_basename(src, values['file_formatting'])
                     basename = parent_prefix + basename
 


### PR DESCRIPTION
**Motivation**

Movies with a type "sequence" fail during collection due to the path not being formatted during resolution.

**Changes**

This fix modifies the src for sequence component types