### PR TITLE
Use new standalone path to launch pyblish

### DIFF
--- a/pipeline_plugins/resource/hook/celaction.py
+++ b/pipeline_plugins/resource/hook/celaction.py
@@ -121,8 +121,6 @@ class CelActionAction(object):
 
         context = event["data"].copy()
 
-        tools_path = os.getenv("NETWORK_TOOLS_PATH", os.path.dirname(__file__))
-
         # setting output parameters
         path = r"Software\CelAction\CelAction2D\User Settings"
         _winreg.CreateKey(_winreg.HKEY_CURRENT_USER, path)
@@ -130,7 +128,9 @@ class CelActionAction(object):
                                r"Software\CelAction\CelAction2D\User Settings",
                                0, _winreg.KEY_ALL_ACCESS)
 
-        path = os.path.join(tools_path, "pyblish", "pyblish_standalone.bat")
+        root_path = os.getenv("PIPELINE_ROOT", os.path.dirname(__file__))
+        path = os.path.join(root_path, "launchers", "pyblish_standalone.bat")
+
         _winreg.SetValueEx(hKey, "SubmitAppTitle", 0, _winreg.REG_SZ, path)
 
         parameters = " --path \"*SCENE*\" -d chunk *CHUNK* -d start *START*"

--- a/pipeline_plugins/resource/hook/celaction_network.py
+++ b/pipeline_plugins/resource/hook/celaction_network.py
@@ -129,9 +129,9 @@ class CelActionActionNetwork(object):
                                r"Software\CelAction\CelAction2D\User Settings",
                                0, _winreg.KEY_ALL_ACCESS)
 
-        pyblish_path = os.path.dirname(os.path.dirname(__file__))
-        pyblish_path = os.path.join(os.path.dirname(pyblish_path), "pyblish")
-        pyblish_path = os.path.join(pyblish_path, "pyblish_standalone.bat")
+        root_path = os.getenv("PIPELINE_ROOT", os.path.dirname(__file__))
+        pyblish_path = os.path.join(root_path, "launchers", "pyblish_standalone.bat")
+
         _winreg.SetValueEx(hKey, "SubmitAppTitle", 0, _winreg.REG_SZ,
                            pyblish_path)
 


### PR DESCRIPTION
**Motivation**

Celaction pyblish submission automatically defaults to an old version of the pyblish startup.bat, based on the old pipeline.

**Changes**

Update paths to point to the new pipeline launcher folder.